### PR TITLE
fix: support continuous pursuit confirmation dialog

### DIFF
--- a/assets/resource/base/pipeline/fight/bounty_hunt.json
+++ b/assets/resource/base/pipeline/fight/bounty_hunt.json
@@ -211,7 +211,8 @@
 			"type": "TemplateMatch",
 			"param": {
 				"template": ["fight/自动追击10次.png"],
-				"roi": [326, 910, 76, 173]
+				"roi": [326, 910, 76, 173],
+				"threshold": [0.6]
 			}
 		},
 		"action": {
@@ -221,7 +222,24 @@
 		"focus": {
 			"Node.Action.Succeeded": "追击10次"
 		},
-		"next": ["[JumpBack]退出点击（上限）popop", "stop"]
+		"next": ["零点连续追击确认", "[JumpBack]退出点击（上限）popop", "stop"]
+	},
+	"零点连续追击确认": {
+		"recognition": {
+			"type": "OCR",
+			"param": {
+				"expected": ["连续追击次数", "追击次数", "连续追击"],
+				"roi": [250, 400, 240, 190]
+			}
+		},
+		"action": {
+			"type": "Click",
+			"param": {
+				"target": [320, 650, 90, 45]
+			}
+		},
+		"post_delay": 3000,
+		"next": []
 	},
 	"零点自动追击体力耗尽": {
 		"recognition": {
@@ -233,7 +251,8 @@
 							"type": "TemplateMatch",
 							"param": {
 								"template": ["fight/自动追击10次.png"],
-								"roi": [326, 910, 76, 173]
+								"roi": [326, 910, 76, 173],
+								"threshold": [0.6]
 							}
 						}
 					},
@@ -257,6 +276,7 @@
 			"Node.Action.Succeeded": "自动追击体力耗尽"
 		},
 		"next": [
+			"零点连续追击确认",
 			"体力耗尽不再继续",
 			"[JumpBack]零点自动追击10次重复",
 			"[JumpBack]零点自动追击1次重复"
@@ -267,7 +287,8 @@
 			"type": "TemplateMatch",
 			"param": {
 				"template": ["fight/自动追击10次.png"],
-				"roi": [326, 910, 76, 173]
+				"roi": [326, 910, 76, 173],
+				"threshold": [0.6]
 			}
 		},
 		"action": {
@@ -275,7 +296,7 @@
 			"param": {}
 		},
 		"post_delay": 500,
-		"next": []
+		"next": ["零点连续追击确认"]
 	},
 	"零点自动追击1次重复": {
 		"recognition": {

--- a/assets/resource/base/pipeline/fight/daily_fight_xinhe.json
+++ b/assets/resource/base/pipeline/fight/daily_fight_xinhe.json
@@ -180,7 +180,8 @@
 			"type": "TemplateMatch",
 			"param": {
 				"template": ["fight/自动追击10次.png"],
-				"roi": [310, 1135, 65, 109]
+				"roi": [310, 1135, 65, 109],
+				"threshold": [0.6]
 			}
 		},
 		"action": {
@@ -190,14 +191,32 @@
 		"focus": {
 			"Node.Action.Succeeded": "追击10次"
 		},
-		"next": ["[JumpBack]退出点击（上限）popop", "stop"]
+		"next": ["芯核连续追击确认", "[JumpBack]退出点击（上限）popop", "stop"]
+	},
+	"芯核连续追击确认": {
+		"recognition": {
+			"type": "OCR",
+			"param": {
+				"expected": ["连续追击次数", "追击次数", "连续追击"],
+				"roi": [250, 400, 240, 190]
+			}
+		},
+		"action": {
+			"type": "Click",
+			"param": {
+				"target": [320, 650, 90, 45]
+			}
+		},
+		"post_delay": 3000,
+		"next": []
 	},
 	"芯核自动追击耗尽": {
 		"recognition": {
 			"type": "TemplateMatch",
 			"param": {
 				"template": ["fight/自动追击10次.png"],
-				"roi": [310, 1135, 65, 109]
+				"roi": [310, 1135, 65, 109],
+				"threshold": [0.6]
 			}
 		},
 		"action": {
@@ -208,6 +227,7 @@
 			"Node.Action.Succeeded": "自动追击体力耗尽"
 		},
 		"next": [
+			"芯核连续追击确认",
 			"体力耗尽不再继续",
 			"芯核上限不再继续",
 			"[JumpBack]芯核自动追击10次重复",
@@ -219,14 +239,15 @@
 			"type": "TemplateMatch",
 			"param": {
 				"template": ["fight/自动追击10次.png"],
-				"roi": [310, 1135, 65, 109]
+				"roi": [310, 1135, 65, 109],
+				"threshold": [0.6]
 			}
 		},
 		"action": {
 			"type": "Click",
 			"param": {}
 		},
-		"next": []
+		"next": ["芯核连续追击确认"]
 	},
 	"芯核自动追击1次重复": {
 		"recognition": {


### PR DESCRIPTION
## Summary

- lower the template threshold for the updated continuous pursuit button in bounty hunt and core hunt flows
- add a confirmation step for the new continuous pursuit count dialog before leaving the battle page
- apply the same dialog handling to fixed 10x pursuit and repeat/exhaustion pursuit paths

## Context

Love and Deepspace 5.0 updated the pursuit UI. The old `自动追击10次` button now appears as `连续追击`, and tapping it opens a count dialog that defaults to 10 runs and requires an extra confirmation tap. Without this step, MaaLYSK can enter the battle page and then wait without starting the run.

Observed on MuMu 12 at 900x1600: the old template still matches the new button around score 0.66, below the default 0.70 threshold, and the confirmation dialog shows `连续追击次数` / `追击次数 10/24` with the confirm button centered below.

## Validation

- JSON syntax checked for both modified pipeline files with `python3 -m json.tool`
- `git diff --check` passed
- Live local install patch was applied and the dialog was visually confirmed on the updated game UI

Full `check_resource.py` was not run locally because the `maa` Python module is not installed in this environment.
