### PR TITLE
修复星间加速和每日签到入口

### DIFF
--- a/assets/resource/base/pipeline/daily/daily_end.json
+++ b/assets/resource/base/pipeline/daily/daily_end.json
@@ -164,6 +164,22 @@
 		"timeout": 5000,
 		"next": ["日常签到准备"]
 	},
+	"进入每日签到任务": {
+		"recognition": {
+			"type": "DirectHit",
+			"param": {}
+		},
+		"action": {
+			"type": "DoNothing",
+			"param": {}
+		},
+		"next": [
+			"日常签到准备",
+			"[JumpBack]点击日程",
+			"[JumpBack]返回上一级页面",
+			"[JumpBack]导航回主页面"
+		]
+	},
 	"日常签到准备": {
 		"recognition": {
 			"type": "OCR",

--- a/assets/resource/base/pipeline/daily/daily_star_detection.json
+++ b/assets/resource/base/pipeline/daily/daily_star_detection.json
@@ -1,233 +1,596 @@
 {
-	"进入星间探测": {
-		"recognition": {
-			"type": "DirectHit",
-			"param": {}
-		},
-		"action": {
-			"type": "DoNothing",
-			"param": {}
-		},
-		"next": [
-			"星间探测准备",
-			"[JumpBack]点击许愿",
-			"[JumpBack]返回上一级页面",
-			"[JumpBack]导航回主页面"
-		]
-	},
-	"星间探测准备": {
-		"recognition": {
-			"type": "OCR",
-			"param": {
-				"expected": ["星间探测", "星间", "探测"],
-				"roi": [626, 107, 71, 66]
-			}
-		},
-		"action": {
-			"type": "Click",
-			"param": {}
-		},
-		"post_delay": 2000,
-		"next": [
-			"是否探测中",
-			"收取探测信号",
-			"银砂星系_开始探测",
-			"[JumpBack]前往银砂星系"
-		]
-	},
-	"是否探测中": {
-		"recognition": {
-			"type": "OCR",
-			"param": {
-				"expected": ["信号探测中", "中", "探测中"],
-				"roi": [211, 497, 285, 65]
-			}
-		},
-		"action": {
-			"type": "DoNothing",
-			"param": {}
-		},
-		"focus": {
-			"Node.Recognition.Succeeded": "探测未完成"
-		},
-		"next": ["结束探测"]
-	},
-	"结束探测": {
-		"recognition": {
-			"type": "TemplateMatch",
-			"param": {
-				"template": ["star_detection/星间探测_结束探测.png"],
-				"roi": [474, 1011, 56, 56]
-			}
-		},
-		"action": {
-			"type": "Click",
-			"param": {}
-		},
-		"next": ["确定结束探测"]
-	},
-	"确定结束探测": {
-		"recognition": {
-			"type": "TemplateMatch",
-			"param": {
-				"template": ["确定.png"],
-				"roi": [379, 698, 207, 74]
-			}
-		},
-		"action": {
-			"type": "Click",
-			"param": {
-				"target_offset": [4, 4, -2, -2]
-			}
-		},
-		"focus": {
-			"Node.Action.Succeeded": "<span style=\"color:orange\">消耗加速魔方进行收取</span>"
-		},
-		"next": ["收取探测信号", "[JumpBack]星间探测点击"]
-	},
-	"收取探测信号": {
-		"recognition": {
-			"type": "OCR",
-			"param": {
-				"expected": ["收取信号", "信号", "收取"],
-				"roi": [278, 1061, 179, 67]
-			}
-		},
-		"action": {
-			"type": "Click",
-			"param": {}
-		},
-		"focus": {
-			"Node.Action.Succeeded": "收取上次探测信号"
-		},
-		"pre_delay": 500,
-		"post_delay": 2000,
-		"next": [
-			"银砂星系_开始探测",
-			"[JumpBack]前往银砂星系",
-			"[JumpBack]星间探测点击"
-		]
-	},
-	"星间探测点击": {
-		"recognition": {
-			"type": "DirectHit",
-			"param": {}
-		},
-		"action": {
-			"type": "Click",
-			"param": {
-				"target": [19, 936, 12, 13]
-			}
-		},
-		"next": []
-	},
-	"前往银砂星系": {
-		"recognition": {
-			"type": "OCR",
-			"param": {
-				"expected": ["前往银砂星系", "前往银砂", "银砂"],
-				"roi": [151, 1000, 171, 51]
-			}
-		},
-		"action": {
-			"type": "Click",
-			"param": {}
-		},
-		"pre_delay": 1000,
-		"post_delay": 1000,
-		"next": []
-	},
-	"银砂星系_开始探测": {
-		"recognition": {
-			"type": "OCR",
-			"param": {
-				"expected": ["开始探测", "探测", "开始"],
-				"roi": [180, 1007, 114, 118]
-			}
-		},
-		"action": {
-			"type": "Click",
-			"param": {
-				"target_offset": [15, 10, -30, -20]
-			}
-		},
-		"pre_delay": 1000,
-		"post_delay": 1000,
-		"next": ["确认消耗银砂磁石"]
-	},
-	"确认消耗银砂磁石": {
-		"recognition": {
-			"type": "TemplateMatch",
-			"param": {
-				"template": ["确定.png"],
-				"roi": [384, 637, 186, 56]
-			}
-		},
-		"action": {
-			"type": "Click",
-			"param": {
-				"target": [456, 655, 42, 14]
-			}
-		},
-		"pre_delay": 1000,
-		"focus": {
-			"Node.Action.Succeeded": "银砂星系探测完成"
-		},
-		"next": ["stop"]
-	},
-	"辉曜星系_开始探测": {
-		"recognition": {
-			"type": "OCR",
-			"param": {
-				"expected": ["开始探测", "探测", "开始"],
-				"roi": [425, 1013, 116, 111]
-			}
-		},
-		"action": {
-			"type": "Click",
-			"param": {
-				"target_offset": [30, 30, -60, -60]
-			}
-		},
-		"pre_delay": 1000,
-		"post_delay": 1000,
-		"next": ["确认消耗辉曜磁石"]
-	},
-	"确认消耗辉曜磁石": {
-		"recognition": {
-			"type": "TemplateMatch",
-			"param": {
-				"template": ["确定.png"],
-				"roi": [384, 637, 186, 56]
-			}
-		},
-		"action": {
-			"type": "Click",
-			"param": {
-				"target": [456, 655, 42, 14]
-			}
-		},
-		"pre_delay": 500,
-		"post_delay": 500,
-		"focus": {
-			"Node.Action.Succeeded": "辉曜星系探测完成"
-		},
-		"next": ["stop"]
-	},
-	"前往辉曜星系": {
-		"recognition": {
-			"type": "OCR",
-			"param": {
-				"expected": ["前往辉曜星系", "前往辉曜", "辉曜"],
-				"roi": [429, 1004, 153, 45]
-			}
-		},
-		"action": {
-			"type": "Click",
-			"param": {}
-		},
-		"pre_delay": 1000,
-		"post_delay": 1000,
-		"next": []
-	}
+    "进入星间探测": {
+        "recognition": {
+            "type": "DirectHit",
+            "param": {}
+        },
+        "action": {
+            "type": "DoNothing",
+            "param": {}
+        },
+        "next": [
+            "取消退出探测弹窗",
+            "确认消耗辉曜磁石",
+            "确认消耗银砂磁石",
+            "是否探测中",
+            "确认消耗加速魔方并收取",
+            "确定结束探测",
+            "星间探测准备",
+            "[JumpBack]点击许愿",
+            "[JumpBack]返回上一级页面",
+            "[JumpBack]导航回主页面"
+        ]
+    },
+    "星间探测准备": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "星间探测",
+                    "星间",
+                    "探测"
+                ],
+                "roi": [
+                    626,
+                    107,
+                    71,
+                    66
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "post_delay": 2000,
+        "next": [
+            "是否探测中",
+            "收取探测信号",
+            "银砂星系_快速探测",
+            "银砂星系_开始探测",
+            "[JumpBack]前往银砂星系"
+        ]
+    },
+    "取消退出探测弹窗": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "取消探测",
+                    "不会返回",
+                    "确定取消"
+                ],
+                "roi": [
+                    90,
+                    450,
+                    540,
+                    220
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    243,
+                    678,
+                    80,
+                    40
+                ]
+            }
+        },
+        "focus": {
+            "Node.Action.Succeeded": "取消退出探测，保留当前探测"
+        },
+        "post_delay": 800,
+        "next": [
+            "是否探测中",
+            "结束探测",
+            "确认消耗加速魔方并收取",
+            "stop"
+        ]
+    },
+    "是否探测中": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "信号探测中",
+                    "返回时间",
+                    "探测中"
+                ],
+                "roi": [
+                    160,
+                    470,
+                    400,
+                    230
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                            "target": [
+                                500,
+                                1040,
+                                70,
+                                80
+                            ]
+            }
+        },
+        "focus": {
+            "Node.Recognition.Succeeded": "探测未完成"
+        },
+        "next": [
+            "确认消耗加速魔方并收取"
+        ],
+        "pre_delay": 200,
+        "post_delay": 1200
+    },
+    "结束探测": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "信号探测中",
+                    "返回时间",
+                    "探测中"
+                ],
+                "roi": [
+                    160,
+                    470,
+                    400,
+                    230
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    500,
+                    1040,
+                    70,
+                    80
+                ]
+            }
+        },
+        "next": [
+            "确认消耗加速魔方并收取"
+        ],
+        "pre_delay": 200,
+        "post_delay": 1200
+    },
+    "确定结束探测": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "快速探测",
+                    "探测次数",
+                    "银砂星系"
+                ],
+                "roi": [
+                    110,
+                    420,
+                    500,
+                    160
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    430,
+                    675,
+                    140,
+                    70
+                ]
+            }
+        },
+        "focus": {
+            "Node.Action.Succeeded": "<span style=\"color:orange\">消耗加速魔方进行收取</span>"
+        },
+        "next": [
+            "确认消耗加速魔方并收取",
+            "收取探测信号",
+            "stop"
+        ],
+        "pre_delay": 300,
+        "post_delay": 2500
+    },
+    "收取探测信号": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "收取信号",
+                    "信号",
+                    "收取"
+                ],
+                "roi": [
+                    278,
+                    1061,
+                    179,
+                    67
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "focus": {
+            "Node.Action.Succeeded": "收取上次探测信号"
+        },
+        "pre_delay": 500,
+        "post_delay": 2000,
+        "next": [
+            "银砂星系_快速探测",
+            "银砂星系_开始探测",
+            "[JumpBack]前往银砂星系",
+            "[JumpBack]星间探测点击"
+        ]
+    },
+    "星间探测点击": {
+        "recognition": {
+            "type": "DirectHit",
+            "param": {}
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    19,
+                    936,
+                    12,
+                    13
+                ]
+            }
+        },
+        "next": []
+    },
+    "前往银砂星系": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "前往银砂星系",
+                    "前往银砂",
+                    "银砂"
+                ],
+                "roi": [
+                    151,
+                    1000,
+                    171,
+                    51
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "pre_delay": 1000,
+        "post_delay": 1000,
+        "next": []
+    },
+    "银砂星系_开始探测": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "开始探测",
+                    "探测",
+                    "开始"
+                ],
+                "roi": [
+                    180,
+                    1007,
+                    114,
+                    118
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target_offset": [
+                    15,
+                    10,
+                    -30,
+                    -20
+                ]
+            }
+        },
+        "pre_delay": 1000,
+        "post_delay": 1000,
+        "next": [
+            "确认消耗银砂磁石"
+        ]
+    },
+    "确认消耗银砂磁石": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "银砂磁石",
+                    "开启探测",
+                    "消耗"
+                ],
+                "roi": [
+                    170,
+                    470,
+                    430,
+                    160
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    430,
+                    640,
+                    140,
+                    70
+                ]
+            }
+        },
+        "pre_delay": 1000,
+        "focus": {
+            "Node.Action.Succeeded": "银砂星系探测完成"
+        },
+        "next": [
+            "结束探测",
+            "是否探测中",
+            "确认消耗加速魔方并收取"
+        ],
+        "post_delay": 1200
+    },
+    "确认消耗加速魔方并收取": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "加速魔方",
+                    "立即完成",
+                    "完成探索"
+                ],
+                "roi": [
+                    110,
+                    420,
+                    500,
+                    160
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    430,
+                    675,
+                    140,
+                    70
+                ]
+            }
+        },
+        "focus": {
+            "Node.Action.Succeeded": "<span style=\"color:orange\">消耗加速魔方完成探测</span>"
+        },
+        "pre_delay": 300,
+        "post_delay": 2500,
+        "next": [
+            "收取探测信号",
+            "stop"
+        ],
+        "on_error": [
+            "确认消耗加速魔方按钮兜底",
+            "结束探测",
+            "是否探测中",
+            "stop"
+        ]
+    },
+    "确认消耗加速魔方按钮兜底": {
+        "recognition": {
+            "type": "DirectHit",
+            "param": {}
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    430,
+                    675,
+                    140,
+                    70
+                ]
+            }
+        },
+        "focus": {
+            "Node.Action.Succeeded": "<span style=\"color:orange\">兜底确认消耗加速魔方</span>"
+        },
+        "pre_delay": 300,
+        "post_delay": 2500,
+        "next": [
+            "收取探测信号",
+            "stop"
+        ]
+    },
+    "辉曜星系_开始探测": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "开始探测",
+                    "探测",
+                    "开始"
+                ],
+                "roi": [
+                    425,
+                    1013,
+                    116,
+                    111
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target_offset": [
+                    30,
+                    30,
+                    -60,
+                    -60
+                ]
+            }
+        },
+        "pre_delay": 1000,
+        "post_delay": 1000,
+        "next": [
+            "确认消耗辉曜磁石"
+        ]
+    },
+    "确认消耗辉曜磁石": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "辉曜磁石",
+                    "开启探测",
+                    "消耗"
+                ],
+                "roi": [
+                    170,
+                    470,
+                    430,
+                    160
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    430,
+                    640,
+                    140,
+                    70
+                ]
+            }
+        },
+        "pre_delay": 500,
+        "post_delay": 1200,
+        "focus": {
+            "Node.Action.Succeeded": "辉曜星系探测完成"
+        },
+        "next": [
+            "结束探测",
+            "是否探测中",
+            "确认消耗加速魔方并收取"
+        ]
+    },
+    "前往辉曜星系": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "前往辉曜星系",
+                    "前往辉曜",
+                    "辉曜"
+                ],
+                "roi": [
+                    429,
+                    1004,
+                    153,
+                    45
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "pre_delay": 1000,
+        "post_delay": 1000,
+        "next": []
+    },
+    "银砂星系_快速探测": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "快速探测",
+                    "快速",
+                    "探测"
+                ],
+                "roi": [
+                    390,
+                    970,
+                    210,
+                    150
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    475,
+                    1000,
+                    70,
+                    80
+                ]
+            }
+        },
+        "focus": {
+            "Node.Action.Succeeded": "点击星间快速探测"
+        },
+        "pre_delay": 300,
+        "post_delay": 1200,
+        "next": [
+            "确定结束探测",
+            "确认消耗加速魔方并收取"
+        ]
+    },
+    "辉曜星系_快速探测": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "快速探测",
+                    "快速",
+                    "探测"
+                ],
+                "roi": [
+                    390,
+                    970,
+                    210,
+                    150
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    475,
+                    1000,
+                    70,
+                    80
+                ]
+            }
+        },
+        "focus": {
+            "Node.Action.Succeeded": "点击辉曜快速探测"
+        },
+        "pre_delay": 300,
+        "post_delay": 1200,
+        "next": [
+            "确定结束探测",
+            "确认消耗加速魔方并收取"
+        ]
+    }
 }

--- a/assets/resource/tasks/DailyTask.json
+++ b/assets/resource/tasks/DailyTask.json
@@ -20,6 +20,13 @@
 			"description": "签到奖励领取,日常任务领取<br><span style=\"color:red\">任务完成后,请自行检查是否领取完毕</span>"
 		},
 		{
+			"name": "📅每日签到",
+			"entry": "进入每日签到任务",
+			"default_check": true,
+			"option": ["是否尝试进行鎏金卡补签"],
+			"description": "只进入签到页领取每日签到和月签到礼包，不处理日常任务奖励。"
+		},
+		{
 			"name": "🪴家园日常",
 			"entry": "进入家园",
 			"default_check": false,

--- a/assets/resource/tasks/StarDetection.json
+++ b/assets/resource/tasks/StarDetection.json
@@ -1,79 +1,122 @@
 {
-	"task": [
-		{
-			"name": "🌌星间探测",
-			"entry": "进入星间探测",
-			"default_check": true,
-			"option": ["是否使用加速魔方", "选择探测星系"],
-			"description": "目前仅支持自动探测一次银砂星系/辉曜星系,快速探测暂不支持"
-		}
-	],
-	"option": {
-		"是否使用加速魔方": {
-			"type": "switch",
-			"cases": [
-				{
-					"name": "No",
-					"pipeline_override": {
-						"是否探测中": {
-							"next": ["stop"]
-						}
-					}
-				},
-				{
-					"name": "Yes",
-					"pipeline_override": {
-						"是否探测中": {
-							"next": ["结束探测"]
-						}
-					}
-				}
-			]
-		},
-		"选择探测星系": {
-			"type": "select",
-			"cases": [
-				{
-					"name": "银砂星系",
-					"pipeline_override": {
-						"星间探测准备": {
-							"next": [
-								"是否探测中",
-								"收取探测信号",
-								"银砂星系_开始探测",
-								"[JumpBack]前往银砂星系"
-							]
-						},
-						"收取探测信号": {
-							"next": [
-								"银砂星系_开始探测",
-								"[JumpBack]前往银砂星系",
-								"[JumpBack]星间探测点击"
-							]
-						}
-					}
-				},
-				{
-					"name": "辉曜星系",
-					"pipeline_override": {
-						"星间探测准备": {
-							"next": [
-								"是否探测中",
-								"收取探测信号",
-								"辉曜星系_开始探测",
-								"[JumpBack]前往辉曜星系"
-							]
-						},
-						"收取探测信号": {
-							"next": [
-								"辉曜星系_开始探测",
-								"[JumpBack]前往辉曜星系",
-								"[JumpBack]星间探测点击"
-							]
-						}
-					}
-				}
-			]
-		}
-	}
+    "task": [
+        {
+            "name": "🌌星间探测",
+            "entry": "进入星间探测",
+            "default_check": true,
+            "option": [
+                "是否使用加速魔方",
+                "选择探测星系"
+            ],
+            "description": "支持银砂星系/辉曜星系探测；选择使用加速魔方时，会尝试点击快速探测、确认消耗魔方并收取奖励。"
+        }
+    ],
+    "option": {
+        "是否使用加速魔方": {
+            "type": "switch",
+            "cases": [
+                {
+                    "name": "No",
+                    "pipeline_override": {
+                        "是否探测中": {
+                            "next": [
+                                "stop"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "是否探测中": {
+                            "recognition": {
+                                "type": "OCR",
+                                "param": {
+                                    "expected": [
+                                        "信号探测中",
+                                        "返回时间",
+                                        "探测中"
+                                    ],
+                                    "roi": [
+                                        160,
+                                        470,
+                                        400,
+                                        230
+                                    ]
+                                }
+                            },
+                            "action": {
+                                "type": "Click",
+                                "param": {
+                                    "target": [
+                                        475,
+                                        1000,
+                                        70,
+                                        80
+                                    ]
+                                }
+                            },
+                            "focus": {
+                                "Node.Action.Succeeded": "点击右侧加速魔方"
+                            },
+                            "pre_delay": 200,
+                            "post_delay": 1200,
+                            "next": [
+                                "确认消耗加速魔方并收取"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "选择探测星系": {
+            "type": "select",
+            "cases": [
+                {
+                    "name": "银砂星系",
+                    "pipeline_override": {
+                        "星间探测准备": {
+                            "next": [
+                                "是否探测中",
+                                "收取探测信号",
+                                "银砂星系_快速探测",
+                                "银砂星系_开始探测",
+                                "[JumpBack]前往银砂星系"
+                            ]
+                        },
+                        "收取探测信号": {
+                            "next": [
+                                "银砂星系_快速探测",
+                                "银砂星系_开始探测",
+                                "[JumpBack]前往银砂星系",
+                                "[JumpBack]星间探测点击"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "辉曜星系",
+                    "pipeline_override": {
+                        "星间探测准备": {
+                            "next": [
+                                "是否探测中",
+                                "收取探测信号",
+                                "辉曜星系_快速探测",
+                                "辉曜星系_开始探测",
+                                "[JumpBack]前往辉曜星系"
+                            ]
+                        },
+                        "收取探测信号": {
+                            "next": [
+                                "辉曜星系_快速探测",
+                                "辉曜星系_开始探测",
+                                "[JumpBack]前往辉曜星系",
+                                "[JumpBack]星间探测点击"
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
 }


### PR DESCRIPTION
这两处是这几天实际跑日活时踩出来的问题，顺手整理成 PR。

### 星间探测

现在星间探测点「开始探测」以后，会多几步：

1. 确认消耗银砂/辉曜磁石
2. 如果选择了使用加速魔方，就点右侧快速探测
3. 确认消耗加速魔方
4. 收取探测奖励

之前的问题是流程确认完磁石就停了，或者进了倒计时但没有继续点魔方，所以每日奖励给的磁石会剩下来。现在银砂和辉曜都补了快速探测入口，也补了魔方确认的兜底。

### 每日签到

我这里遇到过「日常收尾」不一定稳定把签到也处理完，所以加了一个单独的「📅每日签到」任务入口。

它只负责进签到页，领每日签到和月签到礼包，不碰日常任务奖励。这样想单独补签到的时候不用整套日常重跑一遍。

### 验证

本地 Windows + MuMu 跑过几天日活：

- 每日活跃度能到 100+
- 签到页能看到当天已签到
- 补给能正常领取
- 星间银砂/辉曜磁石能清到 0/0

如果有写法不合项目习惯，我可以再跟着改。
