### PR TITLE
fix: 缩小经验瓶选取范围避免出错

### DIFF
--- a/assets/resource/base/pipeline/daily/daily_upgrade.json
+++ b/assets/resource/base/pipeline/daily/daily_upgrade.json
@@ -168,7 +168,9 @@
 		},
 		"action": {
 			"type": "Click",
-			"param": {}
+			"param": {
+				"target_offset": [20, 0, -20, -20]
+			}
 		},
 		"next": []
 	},


### PR DESCRIPTION
避免每日升级一次任务中点击经验瓶时，小概率点到经验瓶说明的问题