### PR TITLE
feat: 新增日服(com.papegames.lysk.jp)启动选项

### DIFF
--- a/assets/resource/tasks/StartUp.json
+++ b/assets/resource/tasks/StartUp.json
@@ -31,6 +31,34 @@
 							"enabled": true
 						}
 					}
+				},
+				{
+					"name": "恋与深空国际服",
+					"pipeline_override": {
+						"恋与深空国际服": {
+							"enabled": true
+						},
+						"sub_启动深空国际服": {
+							"enabled": true
+						}
+					}
+				},
+				{
+					"name": "恋与深空日服",
+					"pipeline_override": {
+						"恋与深空国际服": {
+							"enabled": true
+						},
+						"sub_启动深空国际服": {
+							"enabled": true,
+							"action": {
+								"type": "StartApp",
+								"param": {
+									"package": "com.papegames.lysk.jp"
+								}
+							}
+						}
+					}
 				}
 			]
 		},
@@ -68,6 +96,34 @@
 						},
 						"sub_启动深空官服": {
 							"enabled": true
+						}
+					}
+				},
+				{
+					"name": "恋与深空国际服",
+					"pipeline_override": {
+						"恋与深空国际服": {
+							"enabled": true
+						},
+						"sub_启动深空国际服": {
+							"enabled": true
+						}
+					}
+				},
+				{
+					"name": "恋与深空日服",
+					"pipeline_override": {
+						"恋与深空国际服": {
+							"enabled": true
+						},
+						"sub_启动深空国际服": {
+							"enabled": true,
+							"action": {
+								"type": "StartApp",
+								"param": {
+									"package": "com.papegames.lysk.jp"
+								}
+							}
 						}
 					}
 				}


### PR DESCRIPTION
老师好，我是海外服玩家，用claude写一键日常脚本的过程中意外修改了MAA启动部分，目前能拉起日服客户端，目前我这边看过来没啥bug，特提pr如有冒犯请多担待Orz.

以下是我这边测试的结果：
1.能拉起日服客户端，但如果肉身在国内需要解决代理问题（不会自动打开模拟器的clash，所以可以尝试pc代理+TUN模式）
2.启动过程中如果弹网络连接失败会自动尝试点击关闭窗口重试连接

以下为claude给的描述可供参考：
“## 说明
新增「恋与深空日服」启动选项,支持日服客户端 com.papegames.lysk.jp。

## 改动
- 仅修改 assets/resource/tasks/StartUp.json
- 在两个 select(请选择游戏版本 / 游戏版本)中各新增一个日服 case
- 复用现有国际服节点,通过 pipeline_override 将启动包名覆盖为 com.papegames.lysk.jp
- 不影响官服 / 国际服 / 繁中等已有选项

## 目的
日服客户端此前无法直接选择,手动改本地文件会在资源更新时被覆盖。此 PR 将日服支持固化进仓库。”